### PR TITLE
docs/tutorial.rst: Added missing installation command for conda envir…

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -18,6 +18,7 @@ make it easier to debug.
 
     # if using conda (see note below - conda is distributed with Anaconda)
     $ conda create --yes --name thermostat pandas
+    $ source activate thermostat
     (thermostat)$ pip install thermostat
 
 If you already have an environment, use the following:


### PR DESCRIPTION
…onment.

Creating a conda environment does not activate the environment.
Without the "source activate thermostat" command
pip installs to whatever the current conda environment is,
which defaults to "root".