### PR TITLE
Flaky test fix

### DIFF
--- a/tests/fixtures/thermostats.py
+++ b/tests/fixtures/thermostats.py
@@ -56,7 +56,7 @@ def thermostat_type_1_utc(request):
 def thermostat_type_1_utc_bad(request):
     thermostats = from_csv(get_data_path(request.param))
 
-@pytest.fixture(scope="function", params=["../data/metadata_multiple_same_key.csv"])
+@pytest.fixture(scope="session", params=["../data/metadata_multiple_same_key.csv"])
 def thermostats_multiple_same_key(request):
     thermostats = from_csv(get_data_path(request.param))
     return thermostats

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,6 +28,8 @@ from .fixtures.thermostats import thermostats_multiple_same_key
 from numpy.testing import assert_allclose
 from numpy import isnan
 
+metrics = []
+
 
 def test_zero_days_warning(thermostat_zero_days):
     output = thermostat_zero_days.calculate_epa_field_savings_metrics()
@@ -35,7 +37,6 @@ def test_zero_days_warning(thermostat_zero_days):
 
 
 def test_multiple_same_key(thermostats_multiple_same_key):
-    metrics = []
     for thermostat in thermostats_multiple_same_key:
         outputs = thermostat.calculate_epa_field_savings_metrics()
         metrics.extend(outputs)


### PR DESCRIPTION
Tool: pytest flake-finder:
https://github.com/dropbox/pytest-flakefinder
To run, using cmd:
```
pytest --flake-finder tests/test_core.py
```
Problematic test:
test_multiple_same_key

Error:
Assertion error, len(metrics) == 0

Possible cause:
When rerun the test, it is the same session and the thermostats_multiple_same_key is done iterating. So the metrics is empty.

My fix:
1. (old one)
change fixture scope to function so everytime the test run, a new iterable thermostats_multiple_same_key is returned.

2. (new one)
I feel it might not be proper to change the scope of fixture, so I made metrics a global variable so it will not be flushed in the same session.

Both changes pass pytest and pytest flake-finder.