### PR TITLE
Feature/epa2.0 climate zone weights

### DIFF
--- a/thermostat/climate_zone.py
+++ b/thermostat/climate_zone.py
@@ -40,7 +40,7 @@ CLIMATE_ZONE_MAPPING = {
     }
 
 WEIGHTS = pd.read_csv(
-    Path("Resources") / "NationalAverageClimateZoneWeightings.csv"
+    Path(__file__).parents[0] / "resources" / "NationalAverageClimateZoneWeightings.csv"
     ).set_index('climate_zone')
 HEATING_CLIMATE_ZONE_WEIGHTS = WEIGHTS["heating_weight"].to_dict()
 

--- a/thermostat/climate_zone.py
+++ b/thermostat/climate_zone.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from eeweather.geo import get_lat_long_climate_zones
 import numpy as np
 import logging
+from pathlib import Path
 
 logger = logging.getLogger('epathermostat')
 
@@ -38,20 +39,12 @@ CLIMATE_ZONE_MAPPING = {
     'Mixed-Dry': 'Mixed-Dry/Hot-Dry',
     }
 
+WEIGHTS = pd.read_csv(
+    Path("Resources") / "NationalAverageClimateZoneWeightings.csv"
+    ).set_index('climate_zone')
+HEATING_CLIMATE_ZONE_WEIGHTS = WEIGHTS["heating_weight"].to_dict()
 
-HEATING_CLIMATE_ZONE_WEIGHTS = {
-    'very-cold_cold': 0.549,
-    'mixed-humid': 0.312,
-    'mixed-dry_hot-dry': 0.054,
-    'hot-humid': 0.049,
-    'marine': 0.036}
-
-COOLING_CLIMATE_ZONE_WEIGHTS = {
-    'very-cold_cold': 0.096,
-    'mixed-humid': 0.34,
-    'mixed-dry_hot-dry': 0.144,
-    'hot-humid': 0.42,
-    'marine': 0.0}
+COOLING_CLIMATE_ZONE_WEIGHTS = WEIGHTS["cooling_weight"].to_dict()
 
 
 def retrieve_climate_zone(zipcode):

--- a/thermostat/resources/NationalAverageClimateZoneWeightings.csv
+++ b/thermostat/resources/NationalAverageClimateZoneWeightings.csv
@@ -1,6 +1,6 @@
 climate_zone,heating_weight,cooling_weight
-very-cold/cold,0.564,0.194
+very-cold_cold,0.564,0.194
 mixed-humid,0.294,0.311
-mixed-dry/hot-Dry,0.051,0.137
+mixed-dry_hot-dry,0.051,0.137
 hot-humid,0.054,0.345
 marine,0.037,0.013

--- a/thermostat/resources/NationalAverageClimateZoneWeightings.csv
+++ b/thermostat/resources/NationalAverageClimateZoneWeightings.csv
@@ -1,6 +1,6 @@
 climate_zone,heating_weight,cooling_weight
-Very-Cold/Cold,0.549,0.096
-Mixed-Humid,0.312,0.340
-Mixed-Dry/Hot-Dry,0.054,0.144
-Hot-Humid,0.049,0.420
-Marine,0.036,0.000
+very-cold/cold,0.564,0.194
+mixed-humid,0.294,0.311
+mixed-dry/hot-Dry,0.051,0.137
+hot-humid,0.054,0.345
+marine,0.037,0.013


### PR DESCRIPTION
Updated code to read these the updated climate zone weighting factors.

I am a little concerned that the tests don't seem to cover the climate zone file at all.

```
Name                                    Stmts   Miss  Cover   Missing
thermostat/climate_zone.py                 31     16    48%   64-80
```

What is the best way to test this file? I would like to add a test before merging my changes to it in.