### PR TITLE
Only query GHCN-H when the cached series has real gaps

### DIFF
--- a/tests/fixtures/thermostats.py
+++ b/tests/fixtures/thermostats.py
@@ -169,7 +169,7 @@ def metrics_type_1_data():
 
     # this data comes from a script in scripts/test_data_generation.ipynb
     data = [{
-        'sw_version': '1.7.7',
+        'sw_version': '1.7.8',
         'ct_identifier': '8465829e-df0d-449e-97bf-96317c24dec3',
         'equipment_type': 1,
         'heating_or_cooling': 'cooling_ALL',
@@ -211,7 +211,7 @@ def metrics_type_1_data():
         'core_mean_indoor_temperature': 73.95971753003002,
         'core_mean_outdoor_temperature': 79.8426321875
         }, {
-        'sw_version': '1.7.7',
+        'sw_version': '1.7.8',
         'ct_identifier': '8465829e-df0d-449e-97bf-96317c24dec3',
         'equipment_type': 1,
         'heating_or_cooling': 'heating_ALL',

--- a/tests/test_eeweather_wrapper.py
+++ b/tests/test_eeweather_wrapper.py
@@ -183,25 +183,27 @@ def test_empty_index_returns_empty_series():
 # Test: date-based auto-routing to GHCN-H at NOAA_OUTAGE_DATE boundary
 # ---------------------------------------------------------------------------
 
-def test_ghcnh_called_automatically_for_post_outage_dates():
-    """Requests ending on or after NOAA_OUTAGE_DATE trigger GHCN-H without NaN."""
+def test_ghcnh_not_called_for_post_outage_complete_data():
+    """Post-outage requests whose cached data has no NaN must NOT hit GHCN-H.
+
+    The fallback is driven by real gaps, not by the calendar: a primed cache
+    (e.g. hours previously written back from GHCN-H) serves entirely offline
+    even for date ranges inside the outage window.
+    """
     full_ts, warns = _full_tempC("2025-01-01", periods=8760)
-    # No NaN in eeweather response — but date range crosses the outage date.
+    # No NaN in eeweather response, and the date range crosses the outage date.
     post_outage_index = pd.date_range(
         NOAA_OUTAGE_DATE, periods=24, freq="h", tz=pytz.UTC
     )
 
     with patch("thermostat.eeweather_wrapper.eeweather.load_isd_hourly_temp_data",
                return_value=(full_ts, warns)), \
-         patch("thermostat.eeweather_wrapper.eeweather.get_isd_station_metadata",
-               return_value={"recent_wban_id": "23234"}), \
-         patch("thermostat.eeweather_wrapper.weather_fallback.fetch_ghcnh_hourly_temp_data",
-               return_value=_ghcnh_fill(full_ts.index)) as mock_ghcnh, \
-         patch("thermostat.eeweather_wrapper.eeweather.write_isd_hourly_temp_data_to_cache"):
+         patch("thermostat.eeweather_wrapper.weather_fallback.fetch_ghcnh_hourly_temp_data") as mock_ghcnh:
 
-        get_indexed_temperatures_eeweather("722880", post_outage_index)
+        result = get_indexed_temperatures_eeweather("722880", post_outage_index)
 
-    mock_ghcnh.assert_called_once()
+    mock_ghcnh.assert_not_called()
+    assert result.notna().all()
 
 
 def test_ghcnh_not_called_for_pre_outage_complete_data():

--- a/thermostat/__init__.py
+++ b/thermostat/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 7, 7)
+VERSION = (1, 7, 8)
 
 def get_version():
     return '{}.{}.{}'.format(VERSION[0], VERSION[1], VERSION[2])

--- a/thermostat/eeweather_wrapper.py
+++ b/thermostat/eeweather_wrapper.py
@@ -21,8 +21,10 @@ from thermostat import weather_fallback
 eeweather.stations.DATA_EXPIRATION_DAYS = 100 * 365  # ~100 years: effectively never
 
 # First date for which the NOAA global-hourly API stopped returning data.
-# Any request whose end date falls on or after this date routes directly to
-# GHCN-H for the affected portion rather than waiting for a NaN-detection pass.
+# Retained as documentation of the outage start; the GHCN-H fallback is now
+# driven purely by whether the cached series actually has gaps (see
+# get_indexed_temperatures_eeweather), so a primed cache serves offline and the
+# network is only touched for genuinely missing hours.
 NOAA_OUTAGE_DATE = pd.Timestamp("2025-08-30", tz="UTC")
 
 # This routine is a compact and distilled version of code that was originally
@@ -64,9 +66,13 @@ def _fill_gaps_with_ghcnh(tempC, usaf_id, start, end):
     """Fill NaN values in tempC using NOAA GHCN-H data for the same station.
 
     Only NaN positions are overwritten; valid cached data is preserved.
-    Returns tempC unchanged if the station has no WBAN ID or the fallback
-    returns no data.
+    Returns tempC unchanged if there are no gaps to fill, if the station has no
+    WBAN ID, or if the fallback returns no data.
     """
+    if not tempC.isna().any():
+        # Cache already covers the requested range — no network request needed.
+        return tempC
+
     try:
         metadata = eeweather.get_isd_station_metadata(usaf_id)
         wban_id = metadata.get("recent_wban_id")
@@ -135,9 +141,11 @@ def get_indexed_temperatures_eeweather(usaf_id, index):
         # so the GHCN-H fallback below can fill the gap.
         tempC = pd.Series(np.nan, index=pd.date_range(start, end, freq="H", tz="UTC"), dtype=float)
         warnings = []
-    # Route to GHCN-H without waiting for NaN detection when the request
-    # overlaps the known NOAA outage period, or as a general NaN fallback.
-    if end >= NOAA_OUTAGE_DATE or tempC.isna().any():
+    # Fill from GHCN-H only when the cached series actually has gaps. A primed
+    # cache (including hours previously written back from GHCN-H) therefore
+    # serves entirely offline; the NCEI network is touched only for genuinely
+    # missing hours, not on every current-period lookup.
+    if tempC.isna().any():
         tempC = _fill_gaps_with_ghcnh(tempC, usaf_id, start, end)
     tempC = tempC.resample('H').mean()[index]
     tempF = _convert_to_farenheit(tempC)


### PR DESCRIPTION
required request not needed if cache here, only pull missing
Bump version to 1.7.8.