### PR TITLE
Pin outbound HTTP to IPv4; NOAA's IPv6 endpoints do not respond

### DIFF
--- a/tests/fixtures/thermostats.py
+++ b/tests/fixtures/thermostats.py
@@ -169,7 +169,7 @@ def metrics_type_1_data():
 
     # this data comes from a script in scripts/test_data_generation.ipynb
     data = [{
-        'sw_version': '1.7.8',
+        'sw_version': '1.7.9',
         'ct_identifier': '8465829e-df0d-449e-97bf-96317c24dec3',
         'equipment_type': 1,
         'heating_or_cooling': 'cooling_ALL',
@@ -211,7 +211,7 @@ def metrics_type_1_data():
         'core_mean_indoor_temperature': 73.95971753003002,
         'core_mean_outdoor_temperature': 79.8426321875
         }, {
-        'sw_version': '1.7.8',
+        'sw_version': '1.7.9',
         'ct_identifier': '8465829e-df0d-449e-97bf-96317c24dec3',
         'equipment_type': 1,
         'heating_or_cooling': 'heating_ALL',

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,65 @@
+import socket
+
+import pytest
+
+from thermostat import _network
+
+
+@pytest.fixture
+def reset_pin(monkeypatch):
+    """Give each test a dual-stack starting point, then restore.
+
+    Importing thermostat already applies the pin, so the resolver has to be put
+    back to its dual-stack behaviour before a test can observe force_ipv4 doing
+    anything.
+    """
+    urllib3_connection = pytest.importorskip("urllib3.util.connection")
+    original = urllib3_connection.allowed_gai_family
+    urllib3_connection.allowed_gai_family = lambda: socket.AF_UNSPEC
+    monkeypatch.setattr(_network, "_applied", False)
+    yield urllib3_connection
+    urllib3_connection.allowed_gai_family = original
+    _network._applied = True
+
+
+def test_force_ipv4_pins_address_family(reset_pin, monkeypatch):
+    monkeypatch.delenv(_network.ALLOW_IPV6_ENV_VAR, raising=False)
+
+    assert _network.force_ipv4() is True
+    assert reset_pin.allowed_gai_family() == socket.AF_INET
+
+
+def test_force_ipv4_is_idempotent(reset_pin, monkeypatch):
+    monkeypatch.delenv(_network.ALLOW_IPV6_ENV_VAR, raising=False)
+
+    assert _network.force_ipv4() is True
+    assert _network.force_ipv4() is True
+    assert reset_pin.allowed_gai_family() == socket.AF_INET
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_env_var_opts_out(reset_pin, monkeypatch, value):
+    monkeypatch.setenv(_network.ALLOW_IPV6_ENV_VAR, value)
+
+    assert _network.force_ipv4() is False
+    assert reset_pin.allowed_gai_family() == socket.AF_UNSPEC
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", ""])
+def test_env_var_other_values_do_not_opt_out(reset_pin, monkeypatch, value):
+    monkeypatch.setenv(_network.ALLOW_IPV6_ENV_VAR, value)
+
+    assert _network.force_ipv4() is True
+    assert reset_pin.allowed_gai_family() == socket.AF_INET
+
+
+def test_importing_thermostat_applies_the_pin():
+    """The pin must not require any action from the caller.
+
+    Manufacturers run this package unmodified, so importing it has to be enough.
+    """
+    urllib3_connection = pytest.importorskip("urllib3.util.connection")
+
+    import thermostat  # noqa: F401  (import is the assertion)
+
+    assert urllib3_connection.allowed_gai_family() == socket.AF_INET

--- a/thermostat/__init__.py
+++ b/thermostat/__init__.py
@@ -1,7 +1,14 @@
-VERSION = (1, 7, 8)
+VERSION = (1, 7, 9)
 
 def get_version():
     return '{}.{}.{}'.format(VERSION[0], VERSION[1], VERSION[2])
+
+# NOAA's NCEI hostnames resolve to IPv6 addresses that do not accept
+# connections, which makes every weather request fail or hang on dual-stack
+# hosts. Pin outbound HTTP to IPv4 before anything can open a connection. See
+# thermostat/_network.py for the full rationale and the opt-out env var.
+from ._network import force_ipv4
+force_ipv4()
 
 # This try/except clause is a hack to make the get_version method work for the
 # initial setup, which will fail with an ImportError because pandas hasn't yet

--- a/thermostat/_network.py
+++ b/thermostat/_network.py
@@ -1,0 +1,80 @@
+"""Pin outbound HTTP to IPv4.
+
+NOAA publishes AAAA (IPv6) records for www.ncei.noaa.gov whose endpoints do not
+accept connections.  As of 2026-08-02 none of the six advertised addresses
+(2610:20:8040:2::167/168/171/172/177/178) answer ICMP or accept TCP on port 443,
+while all six IPv4 addresses (205.167.25.167/168/171/172/177/178) serve the Data
+Access API normally.
+
+getaddrinfo sorts IPv6 ahead of IPv4 on dual-stack hosts (RFC 6724), so every
+NCEI request from such a host is attempted against a dead endpoint first.  Hosts
+with no IPv6 route fail immediately with [Errno 101] ENETUNREACH; hosts whose
+IPv6 traffic is blackholed hang for roughly two minutes per address instead.
+
+eeweather's ISD fetch (eeweather.access_api.make_api_request) is wrapped in
+@retry(tries=3) and calls requests.get with no timeout, so this surfaces as:
+
+    HTTPSConnectionPool(host='www.ncei.noaa.gov', port=443): Max retries
+    exceeded with url: /access/services/data/v1?dataTypes=TMP&dataset=...
+
+The consequence is not limited to failed runs.  When the ISD fetch fails but a
+cached series is available, thermostat.weather_fallback swallows the resulting
+GHCN-H error and returns an empty series, leaving the gaps unfilled.  Days with
+more than two missing hours are then dropped from the core day set by
+Thermostat._get_core_day_sets, so metrics are computed over a shorter period
+with nothing in the output to indicate it.
+
+Pinning the address family to AF_INET restores normal operation.  This is a
+workaround for a defect on NOAA's side, not a permanent change.  Once NOAA's
+IPv6 endpoints respond, set THERMOSTAT_ALLOW_IPV6=1 to restore dual-stack
+resolution without modifying this package, then remove this module.
+"""
+import logging
+import os
+import socket
+
+logger = logging.getLogger(__name__)
+
+#: Set to 1/true/yes to skip the pin and use normal dual-stack resolution.
+ALLOW_IPV6_ENV_VAR = "THERMOSTAT_ALLOW_IPV6"
+
+_applied = False
+
+
+def _opted_out():
+    return os.environ.get(ALLOW_IPV6_ENV_VAR, "").strip().lower() in (
+        "1", "true", "yes", "on")
+
+
+def force_ipv4():
+    """Make urllib3 resolve hostnames to IPv4 addresses only.
+
+    Applies process-wide to every connection made through requests/urllib3, and
+    is safe to call more than once.  Returns True if the pin is now in effect.
+    """
+    global _applied
+
+    if _applied:
+        return True
+
+    if _opted_out():
+        logger.debug(
+            "%s is set; leaving dual-stack name resolution in place",
+            ALLOW_IPV6_ENV_VAR)
+        return False
+
+    try:
+        import urllib3.util.connection as urllib3_connection
+    except ImportError:
+        # urllib3 is absent during initial setup, before dependencies install.
+        return False
+
+    # urllib3's create_connection looks allowed_gai_family up in its own module
+    # globals on every call, so replacing the attribute is enough; no connection
+    # pool or session needs to be rebuilt.
+    urllib3_connection.allowed_gai_family = lambda: socket.AF_INET
+    _applied = True
+    logger.debug(
+        "Pinned outbound HTTP to IPv4 (NOAA IPv6 endpoints unreachable); "
+        "set %s=1 to disable.", ALLOW_IPV6_ENV_VAR)
+    return True


### PR DESCRIPTION
With Claude's help, I looked into this issue. As far as I can tell, it's an issue with IPv4 and IPv6 for www.ncei.noaa.gov. The code prioritizes the IPv6 connections, but for some reason those are all dark.

```
curl -4 -w '%{time_connect} %{time_starttransfer}\n' -o /dev/null https://www.ncei.noaa.gov/

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 34337    0 34337    0     0  35104      0 --:--:-- --:--:-- --:--:-- 35073
0.158327 0.568547

curl -6 -w '%{time_connect} %{time_starttransfer}\n' -o /dev/null https://www.ncei.noaa.gov/

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:04:27 --:--:--     0
curl: (7) Failed to connect to www.ncei.noaa.gov port 443 after 267038 ms: Couldn't connect to server
```

Detailed LLM explanation below:


www.ncei.noaa.gov publishes six AAAA records
(2610:20:8040:2::167/168/171/172/177/178). None of them answer ICMP or accept TCP on port 443. All six IPv4 addresses (205.167.25.167/168/171/172/177/178) serve the Data Access API normally and return correct data in under a second.

getaddrinfo sorts IPv6 ahead of IPv4 on dual-stack hosts (RFC 6724), so every NCEI request is attempted against a dead endpoint first. Hosts with no IPv6 route fail immediately with [Errno 101] ENETUNREACH; hosts whose IPv6 traffic is blackholed hang instead, roughly two minutes per address. eeweather's ISD fetch is wrapped in @retry(tries=3) and calls requests.get with no timeout, so partners see:

    WARNING:retry.api:HTTPSConnectionPool(host='www.ncei.noaa.gov', port=443):
    Max retries exceeded with url: /access/services/data/v1?dataTypes=TMP&...

Nothing changed in this package or in partner environments. The change was NOAA publishing AAAA records for a service whose IPv6 side does not answer.

The quiet failure matters more than the loud one. When a cached series is available but has gaps, weather_fallback.fetch_ghcnh_hourly_temp_data catches the connection error and returns an empty series, so the gaps stay unfilled. _get_core_day_sets then drops every day with more than two missing hours. For station 722880 in 2025 that is the difference between 357 and 237 usable days of 365 -- a third of the year removed from the analysis with no error raised and no field in the exported metrics that reflects it. n_days_insufficient_data counts null runtime only, so the loss is invisible downstream.

Pin the address family to AF_INET before any connection can be opened. The pin is applied on import because manufacturers run this package unmodified and cannot add the call themselves. THERMOSTAT_ALLOW_IPV6=1 disables it without a code change, for use once NOAA's IPv6 endpoints respond.

Verified against live NCEI: with an empty cache, a full-year fetch for 722880 completes in about three seconds, GHCN-H fills 2899 of 3043 missing hours, and usable days return to 357/365, matching a fully primed cache.

Note this is separate from the ISD publication gap. ISD global-hourly still returns nothing after August 2025 for this station; GHCN-H covers all twelve months. The existing fallback remains necessary -- this change is what lets it run at all.